### PR TITLE
Timezone display

### DIFF
--- a/templates/eventCards.handlebars
+++ b/templates/eventCards.handlebars
@@ -40,7 +40,7 @@
       {{/if}}
       {{/if}}
       <span class="text-success text-center"><h4>
-        <span class>{{Date}}</span><span class="profile-summary-value"> at {{Time}}{{#if timeZone}}, {{timeZone}}{{/if}}</span></h4></span>
+        <span class>{{Date}}</span><span class="profile-summary-value"> at {{Time}}{{#if Member}}{{#if timeZone}}, {{timeZone}}{{/if}}{{/if}}</span></h4></span>
       <ul class="list-group list-group-flush">
         {{#if Notes}}
         <li class="list-group-item list-item-no-border">{{{Notes}}}

--- a/templates/eventTableRow.handlebars
+++ b/templates/eventTableRow.handlebars
@@ -21,7 +21,7 @@
     </li>
     {{/if}}
     {{#if Time}}
-    <li>{{Time}}{{#if timeZone}}, {{timeZone}}{{/if}}  </li>
+    <li>{{Time}}{{#if Member}}{{#if timeZone}}, {{timeZone}}{{/if}} {{/if}} </li>
     {{/if}}
     {{#if Member}}
     {{#if eventName}}


### PR DESCRIPTION
Right now in your database the 'timeZone' and timeZoneString are both set to the time zone id. This can be confusing to see 'America/Los Angeles' for an event in Seattle, so for now I just hid them.